### PR TITLE
Have a Final Comment Period for RFCs

### DIFF
--- a/mechanics.md
+++ b/mechanics.md
@@ -23,11 +23,43 @@ The issues are intended to record the discussion on the idea, so that's the righ
 
 As decisions are made, the assignee will update the first comment to represent that consensus.
 
-## I'm Working on This!
+## Let's Decide!
+
+First, once the RFC has a clear proposal in the first comment, label it `Phase: Proposal`.
+
+Now get anybody you know will care about this on-board quickly by contacting
+them by whatever means you want: irc, email, @ mentions should all work well.
+As early as possible, get an email out to the tools-tc list if this is going to
+be something more than a couple specific people care about. Use your best
+judgement.  Give a few days for opinions to filter in. Respond promptly if
+possible to avoid a confusing conversation but give enough time for people who
+are PTO or busy etc.  The idea here is to work out any disagreement and come to
+a proposal everyone can live with, so modify the proposal as necessary.
+Reaching consensus is unlikely, but compromise is always possible.
+
+When you feel that everyone is on the same page, it's time for the
+final-comment period.  The intent of this phase is to allow someone to speak up
+and say, "uh, no, that's not what I thought we decided as a group" or "I wasn't
+aware of this proposal, that's crazy", so notification should be distributed
+broadly.  The phase should last long enough for everyone to read the summary
+and speak up, taking into account timezones, PTO, and email backlogs - use your
+best judgement.
+
+Update the issue's label to `Phase: Final Comment` and send a note summarizing
+the proposal and indicating the duration for comments to the tools-taskcluster
+list, or to some other appropriate venue.
+
+When the final comment period has expired, if there have been no objections,
+mark the issue as `Phase: Decided`.  Note that it's OK to have decided RFCs
+which aren't being actively worked on.
+
+## Let's Do It!
 
 Assign the issue to yourself, and to any others working on with you.
 Update the first comment in the issue to point to any related tracking stuff - bugs, repos, etherpads, gists, whatever.
 There's no need to track status in the issue, as long as someone interested can find out by looking at the links.
+
+When the implementation is complete, close the RFC.
 
 ## Labels
 


### PR DESCRIPTION
Currently RFCs hang out in this repo indefinitely and we don't have a way of specifying when a project will actually start to get worked on or to ensure that proper people have signed off on an idea. The following is a proposal to remedy that.

1. We create a new label called "Final Comment Period" or perhaps just "FCP".
2. Any RFC issues with this label attached must be emailed to the taskcluster-tools list. This will be handled manually at first, bonus points if this is automated with a bot or something later?
3. If after 48 hours (not counting weekends) after an issue is sent to the list with the FCP tag attached no comments have been added to the issue, consider the case closed. Any implementation work may begin then. If any comments are added to the issue, you may move the RFC out of FCP stage if issues cannot be resolved quickly.
4. Try to account for people going PTO and such by roping in parties you expect are interested in this topic directly during the "drafting" stage of the RFC. By the time an RFC makes it to the FCP stage, you should not be expecting any feedback.

@djmitche @gregarndt Does this seem like a reasonable outline of this so far? If so, I'll move this out of the drafting stage and send it to the list!