### PR TITLE
Turn off the scheduler service

### DIFF
--- a/rfcs/0076-Turn-off-the-scheduler-service.md
+++ b/rfcs/0076-Turn-off-the-scheduler-service.md
@@ -1,0 +1,8 @@
+# RFC 76 - Turn off the scheduler service
+* Comments: [#76](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/76)
+* Initially Proposed by: @djmitche
+
+# Proposal
+The major known user of this service is release engineering (c.f. https://bugzilla.mozilla.org/show_bug.cgi?id=1259627) and it's unclear how difficult it would be to stop using the service.
+
+This service has not seen much love, and is likely still running in Jonas's Azure account.  If we choose not to sunset it soon, we should update it and move it to the production Azure account.

--- a/rfcs/0076-Turn-off-the-scheduler-service.md
+++ b/rfcs/0076-Turn-off-the-scheduler-service.md
@@ -2,7 +2,15 @@
 * Comments: [#76](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/76)
 * Initially Proposed by: @djmitche
 
-# Proposal
+# Summary
+
+The scheduler service has been deprecated for a long time.
+Let's turn it off.
+
+# Details
+
 The major known user of this service is release engineering (c.f. https://bugzilla.mozilla.org/show_bug.cgi?id=1259627) and it's unclear how difficult it would be to stop using the service.
 
-This service has not seen much love, and is likely still running in Jonas's Azure account.  If we choose not to sunset it soon, we should update it and move it to the production Azure account.
+# Implementation
+
+Tracker: https://bugzilla.mozilla.org/show_bug.cgi?id=1399437


### PR DESCRIPTION
The major known user of this service is release engineering (c.f. https://bugzilla.mozilla.org/show_bug.cgi?id=1259627) and it's unclear how difficult it would be to stop using the service.

This service has not seen much love, and is likely still running in Jonas's Azure account.  If we choose not to sunset it soon, we should update it and move it to the production Azure account.
