### PR TITLE
Migrate queue to postgres

### DIFF
--- a/rfcs/0065-Migrate-queue-to-postgres.md
+++ b/rfcs/0065-Migrate-queue-to-postgres.md
@@ -1,0 +1,26 @@
+# RFC 65 - Migrate queue to postgres
+* Comments: [#65](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/65)
+* Initially Proposed by: @jonasfj
+
+# Proposal
+Pros:
+ * We can do smarter things
+   * for priority
+   * task affinity
+   * querying tasks
+   * statistics
+ * Lots of cheap hosting options:
+   * aws aurora postgres
+   * aws rds postgres
+   * heroku postgres
+   * google cloud SQL postgres
+   * self-hosted postgres
+   * self-hosted cockroachdb (we are close to key-value usage)
+ * We can host in the same data center as our web nodes (reducing latency)
+
+Cons:
+  * It's not a hand-off auto-scaling solution
+  * We can do expensive queries and bring the system down
+
+There is an initial attempt at outlining what the database schema would look at here:
+https://public.etherpad-mozilla.org/p/jonasfj-queue-with-postgres

--- a/rfcs/0065-Migrate-queue-to-postgres.md
+++ b/rfcs/0065-Migrate-queue-to-postgres.md
@@ -2,7 +2,14 @@
 * Comments: [#65](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/65)
 * Initially Proposed by: @jonasfj
 
-# Proposal
+# Summary
+
+The Queue service currently uses a bunch of Azure tables to handle tasks, dependencies, artifacts, and so on.
+
+This project involves refactoring the Queue to use a Postgres backend, instead.
+
+# Motivation
+
 Pros:
  * We can do smarter things
    * for priority
@@ -22,5 +29,11 @@ Cons:
   * It's not a hand-off auto-scaling solution
   * We can do expensive queries and bring the system down
 
+# Details
+
 There is an initial attempt at outlining what the database schema would look at here:
 https://public.etherpad-mozilla.org/p/jonasfj-queue-with-postgres
+
+# Implementaion
+
+* tracker: https://bugzilla.mozilla.org/show_bug.cgi?id=1436478


### PR DESCRIPTION
Pros:
 * We can do smarter things
   * for priority
   * task affinity
   * querying tasks
   * statistics
 * Lots of cheap hosting options:
   * aws aurora postgres
   * aws rds postgres
   * heroku postgres
   * google cloud SQL postgres
   * self-hosted postgres
   * self-hosted cockroachdb (we are close to key-value usage)
 * We can host in the same data center as our web nodes (reducing latency)

Cons:
  * It's not a hand-off auto-scaling solution
  * We can do expensive queries and bring the system down

There is an initial attempt at outlining what the database schema would look at here:
https://public.etherpad-mozilla.org/p/jonasfj-queue-with-postgres