### PR TITLE
Support QEMU in taskcluster-worker

### DIFF
--- a/rfcs/0011-Support-QEMU-in-taskcluster-worker.md
+++ b/rfcs/0011-Support-QEMU-in-taskcluster-worker.md
@@ -2,7 +2,10 @@
 * Comments: [#11](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/11)
 * Initially Proposed by: @djmitche
 
-# Proposal
+# Summary
+
 Build support for running tasks in QEMU in taskcluster-worker.
 
-This may require setting up a packet.net provisioner?
+# Details
+
+This will require setting up a packet.net provisioner.

--- a/rfcs/0011-Support-QEMU-in-taskcluster-worker.md
+++ b/rfcs/0011-Support-QEMU-in-taskcluster-worker.md
@@ -1,0 +1,8 @@
+# RFC 11 - Support QEMU in taskcluster-worker
+* Comments: [#11](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/11)
+* Initially Proposed by: @djmitche
+
+# Proposal
+Build support for running tasks in QEMU in taskcluster-worker.
+
+This may require setting up a packet.net provisioner?


### PR DESCRIPTION
Build support for running tasks in QEMU in taskcluster-worker.

This may require setting up a packet.net provisioner?