### PR TITLE
Define testing best-practices regarding credentials

### DIFF
--- a/rfcs/0110-Best-practices-for-testing-and-credentials.md
+++ b/rfcs/0110-Best-practices-for-testing-and-credentials.md
@@ -1,0 +1,90 @@
+# RFC 110 - Best Practices for testing and Credentials
+* Comments: [#110](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/110)
+* Proposed by: @djmitche
+
+# Summary
+
+Taskcluster repositories should pass their tests "out of the box": `git clone`, `yarn`, and `yarn test` should result in a successful test run.
+
+This is simple for test suites that do not require credentials [1].
+Otherwise, we must find a way to give useful test results when no credentials are available, while ensuring that all tests get run before code goes into production.
+
+Briefly, this proposal suggests a uniform approach to skipping tests that require external services by default, but ensuring that all of those tests run in CI wherever possible.
+To minimze the loss of test coverage from skipped tests, it suggests use of mocks for external services and running tests against both mocks and actual services, when possible.
+
+<sub>[1] or otherwise access external services; such services generally require credentials.</sub>
+
+*NOTE*: this RFC only applies to JavaScript libraries and services.
+
+## Motivation
+
+The testing situation for the Taskcluster services and libraries varies widely from repo to repo, so it is difficult to know what to expect when developing a pull request.
+for some repositories, `yarn test` does not work out of the box, leading to confusion and friction for contributors.
+For others, we have had misconfigurations that fail to run all tests on pull requests or pushes to master, allowing deployment of code to production with failing tests.
+
+The goals of this proposal, then, are:
+
+* A consistent approach to testing across Taskcluster repositories, with a common set of supporting tools
+* Repositories that are approachable for new contributors
+* Confidence that production code has passed *all* tests
+
+# Details
+
+The bulk of this proposal is to document new best practices, as described below.
+The final best-practices documents would be developed in concert with utilities to support them (in `taskcluster-lib-testing`, for example), and follow the usual review process.
+
+Once those best practices and libraries are done, the work that would remain is to upgrade all services and libraries to follow them, and to develop new mocks for the remaining un-mocked external services.
+
+## Best Practices (outline)
+
+### Credential Management
+
+Tests should be capable of fetching credentials needed to access external services either from an on-disk file (for local development) or the Taskcluster-Secrets service vi Taskcluster-Proxy (for use in CI).
+It should be easy to tell if a specific kind of credential (for example, pulse or AWS) is available.
+
+#### Hard Dependencies
+
+Some services and libraries depend completely on external services.
+For example, azure libraries naturally require an Azure account to test against; and pulse libraries will naturally require an AMQP server.
+Similarly, services with database backends cannot be realistically tested without access to a database server.
+
+In such cases, it is OK for the tests to refuse to run at all without configuration for the external services.
+Instead, `yarn test` should fail immediately with a clear message suggesting how to set up access.
+In some cases, this can be accomplished with a `docker` command (e.g., to run RabbitMQ or Postgres); others might require a free-tier account at a hosted service.
+
+The rest of this document does not apply to such cases.
+
+### Test Organization
+
+Test cases that require access to an external service should also be able to run against a mock version of that external service, and should be written such that each test case runs twice, once in each condition.
+When the service credentials are not available, the "real" conditions should be skipped.
+The mock condition test cases should always run.
+If `NO_TEST_SKIP` is set and necessary service credentials are not available, the tests should fail.
+All of this will be supported by utilities in `taskcluster-lib-testing`.
+
+Some external dependencies are too expensive or complex to test against.
+For example, the AWS EC2 APIs are difficult to use in testing, and problems with tests could easily become very expensive.
+In such cases, it's OK to only test against mocks.
+
+In the default configuration, where possible, tests should output only the pass/fail status of each test case (Mocha's default output).
+Any additional diagnostic output should be handled with debug logging or otherwise disabled by default.
+
+### CI Configuration
+
+Tests should run in Taskcluster (via Taskcluster-Github) against both pull requests and pushes to the master branch.
+
+The master branch should be configured with access to a full complement of creentials, so that it can run all tests.
+Depending on the sensitivity of the credentials, pull requests may have access to none, some, or all of the credentials.
+For example, Taskcluster credentials granting access only to create tasks in a testing workerType, with no attached workers, are safe to expose to pull requests; AWS credentials are not.
+
+The Taskcluster-Github configuration should set `NO_TEST_SKIP=1` on the master branch and, if credentials are available, for pull requests.
+This will prevent tests from being silently skipped on master due to a misconfiguration.
+
+*NOTE*: even with better testing, green tests are never enough to guarantee a successful production deploy.
+No amount of automation can substitute for careful thought and manual pre- and post-deployment verification.
+
+# Open Questions
+
+# Implementation
+
+TBD

--- a/rfcs/0110-Best-practices-for-testing-and-credentials.md
+++ b/rfcs/0110-Best-practices-for-testing-and-credentials.md
@@ -82,7 +82,7 @@ Any additional diagnostic output should be handled with debug logging or otherwi
 
 Tests should run in Taskcluster (via Taskcluster-Github) against both pull requests and pushes to the master branch.
 
-The master branch should be configured with access to a full complement of creentials, so that it can run all tests.
+The master branch should be configured with access to a full complement of credentials, so that it can run all tests.
 Depending on the sensitivity of the credentials, pull requests may have access to none, some, or all of the credentials.
 For example, Taskcluster credentials granting access only to create tasks in a testing workerType, with no attached workers, are safe to expose to pull requests; AWS credentials are not.
 

--- a/rfcs/0110-Best-practices-for-testing-and-credentials.md
+++ b/rfcs/0110-Best-practices-for-testing-and-credentials.md
@@ -4,7 +4,7 @@
 
 # Summary
 
-Taskcluster repositories should pass their tests "out of the box": `git clone`, `yarn`, and `yarn test` should result in a successful test run.
+Taskcluster repositories should pass their tests "out of the box": `git clone`, `yarn install --frozen-lockfile`, and `yarn test` should result in a successful test run.
 
 This is simple for test suites that do not require credentials [1].
 Otherwise, we must find a way to give useful test results when no credentials are available, while ensuring that all tests get run before code goes into production.
@@ -37,6 +37,10 @@ Once those best practices and libraries are done, the work that would remain is 
 
 ## Best Practices (outline)
 
+### Installation
+
+Services with a lockfile should suggest that contributors run `yarn install --frozen-lockfile`, while libraries should use `yarn`; after that, run `yarn test`.
+
 ### Credential Management
 
 Tests should be capable of fetching credentials needed to access external services either from an on-disk file (for local development) or the Taskcluster-Secrets service vi Taskcluster-Proxy (for use in CI).
@@ -47,9 +51,8 @@ It should be easy to tell if a specific kind of credential (for example, pulse o
 Team members and dedicated contributors will want to know how to set up a full set of credentials for themselves.
 Include a section in the README describing how to find or generate credentials for each service.
 
-For Taskcluster credentials, put the necessary scopes in `scopes.txt` and suggest that the user use taskcluster-cli to generate the credentials:
-
-> To obtain Taskcluster client credentials, run `eval $(cat scopes.txt | xargs taskcluster-cli signin)`. This will open a web browser and you'll be prompted to log into Taskcluster. This command requires the taskcluster-cli Go application. Find one at https://github.com/taskcluster/taskcluster-cli/releases.
+For Taskcluster credentials, include the necessary credentials in a role named `project:taskcluster:tests:<projectName>` (e.g., `project:taskcluster:tests:taskcluster-queue`).
+Then instruct users to run `eval $(taskcluster-cli signin --scopes assume:project:taskcluster:tests:$PROJECT)` to get the scopes to run the tests, noting that they must themselves have the given role or this won't work.
 
 #### Hard Dependencies
 

--- a/rfcs/0110-Best-practices-for-testing-and-credentials.md
+++ b/rfcs/0110-Best-practices-for-testing-and-credentials.md
@@ -42,6 +42,15 @@ Once those best practices and libraries are done, the work that would remain is 
 Tests should be capable of fetching credentials needed to access external services either from an on-disk file (for local development) or the Taskcluster-Secrets service vi Taskcluster-Proxy (for use in CI).
 It should be easy to tell if a specific kind of credential (for example, pulse or AWS) is available.
 
+#### Getting Credentials
+
+Team members and dedicated contributors will want to know how to set up a full set of credentials for themselves.
+Include a section in the README describing how to find or generate credentials for each service.
+
+For Taskcluster credentials, put the necessary scopes in `scopes.txt` and suggest that the user use taskcluster-cli to generate the credentials:
+
+> To obtain Taskcluster client credentials, run `eval $(cat scopes.txt | xargs taskcluster-cli signin)`. This will open a web browser and you'll be prompted to log into Taskcluster. This command requires the taskcluster-cli Go application. Find one at https://github.com/taskcluster/taskcluster-cli/releases.
+
 #### Hard Dependencies
 
 Some services and libraries depend completely on external services.


### PR DESCRIPTION
We have [some documentation](https://docs.taskcluster.net/manual/design/devel/best-practices/microservices#test-requirements) about how to test microservices, but nothing about libraries.  Even that documentation is advisory in nature ("Where possible, try..").

In this Outreachy round, it has become clear that some services are so difficult to get tests running for that they are basically inaccessible to contributors.  So I'm proposing some more stringent practices with regard to testing, to be followed up with some libraries to assist in implementation of those practices.

Roughly:

 * `yarn && yarn test` should succeed on master for all services and libraries at all times.  If that skips lots of tests, that's OK.
 * When there are mocks available for some dependency, tests should *always* run against the mocks and the same tests should run against the real service when appropriate credentials are available.  It's not hard to run the same test suite twice with different conditions (mock and real, in this case).
 * When there are no mocks available, tests should skip when no credentials are available.
 * When credentials aren't available, the tests against the real service should be skipped
 * For pushes to the master branch of the upstream repo, ensure that all tests are run (no skips)
 * For PR's, depending on the nature of the credentials, either run all tests or skip some of them.  For example, exposing pulse credentials, or TC credentials with only test-related scopes, via a PR is probably OK and will give better feedback to reviewers of contributions.
 * Tests should run primarily via taskcluster-github.  Travis can be used for deployments.
 * Tests should have no non-debug output

As far as implementation, I'd like to start by just setting this up for all services and libraries (with ample help from utilities in taskcluster-lib-testing).  For some services, like Auth, that will mean we skip just about every test by default.

In the second phase, we can start building mocks for the things we still don't have mocks for -- AWS, for example -- as a way of increasing the quality of tests for services and libraries that otherwise have a high proportion of skips.

---

I'd like to gather some thoughts on this before formulating this into a proposal..