### PR TITLE
rewrite taskcluster-events with a proper read-only RabbitMQ / websocket proxy

### DIFF
--- a/rfcs/0104-rewrite-taskcluster-events.md
+++ b/rfcs/0104-rewrite-taskcluster-events.md
@@ -1,0 +1,30 @@
+# RFC 104 - rewrite taskcluster-events with a proper read-only RabbitMQ / websocket proxy
+* Comments: [#104](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/104)
+* Proposed by: @jonasfj
+
+# Summary
+
+Rewrite taskcluster-events to support:
+ * well documented protocol JSON for listening over websocket
+ * one RabbitMQ channel/queue per websocket connection,
+ * bind/unbind to exchanges
+ * resume/pause
+ * automatic reconnection
+ * better abuse protection
+  
+
+## Motivation
+
+ * taskcluster-tools
+ * pulse-inspector
+ * possibly CLI tools
+
+# Details
+
+Compatibility will be broken, client side listener will likely need to have compatibility with existing `WebListener` to make migration easier.
+A new client may be implemented too.
+
+# Open Questions
+
+Final design will be specified in GSoC propsol.
+


### PR DESCRIPTION
At mozilla we have a [RabbitMQ server](https://www.rabbitmq.com/) called `pulse.mozilla.org`, [please read about this setup here](https://wiki.mozilla.org/Auto-tools/Projects/Pulse). In short the system works as follows...

**Publishers:**
 * People who wants to publish messages
 * Registers a `<username>` at [pulseguardian.mozilla.org](https://pulseguardian.mozilla.org/)
 * Creates a topic exchange name: `exchanges/<username>/<exchangeName>`
 * Publishes durable JSON messages to the exchange at-least once for each event
 * Events are published with a routing key of dot separated words, such as: `sleeping.abc.monkey`

**Consumers**:
  * People who wants to listen for messages
  * Registers a `<username>` at [pulseguardian.mozilla.org](https://pulseguardian.mozilla.org/)
  * Creates a queue named `queues/<username>/<queueName>`
  * Binds the exchange of interest to the queue created, with a routing-key pattern:
    * `#` binds to anything
    * `sleeping.#` binds to anything where the first key is `sleeping`
    * `sleeping.*.monkey` binds to anything where the first key is `sleeping` and 3rd key is monkey
    * (see RabbitMQ topic exchanges for more details)
  * Client now reads messages from the queue and acknowleges messages when received

Note:
Often the `<queueName>` is a random UUID and the queue is set to be _exclusive_ meaning other RabbitMQ connections can't consume events from the queue; and the queue also set to be _auto-deleted_  when the connection is closed. Doing this ensures that queues are cleaned up, but also prevents reconnecting without risk of loosing messages.

**taskcluster-events** is a service that listens for incoming websockets, accepts websocket messages in JSON that say what exchanges and routing keys to bind to... it then creates a RabbitMQ channel and queue for each websocket and forwards messages from the queue to the websocket. This way web clients like the [pulse inspector] (https://tools.taskcluster.net/pulse-inspector/) can connect and listen for pulse events without RabbitMQ credentials, nor do web clients need to create a RabbitMQ connection which runs over TCP, making it hard to use RabbitMQ from a web-browser.

However, taskcluster-events is old poorly design, without protocol specification and fairly buggy. This RFC proposes a full rewrite a taskcluster-events which includes a full specification for the websocket protocol.
The project should aim to:
 * Provide a fairly generic read-only websocket proxy for listening to RabbitMQ exchanges,
 * Provide decent abuse protection against build-up of larges queues and too many connections,
   (prefering to refuse connections/clients rather than risk overloading the RabbitMQ cluster)
 * Contain a full specification of the websocket protocol,
 * A client implementation in pure-javascript using WebSockets
 * Prevent webclients from consuming from queues they didn't create, publishing messages or otherwise interfere with other users of the RabbitMQ cluster.

This probably means inventing some fairly high-level websocket protocol.
Rather than trying to proxy the AMQP protocol over a websocket. Though one approach could be to proxy the AMQP protocol, and support enforcement of various limitations, such that clients can't do bad things.

This could be a **GSoC** or **Outreachy** project, or just a fun thing to work on.
@jonasfj and @eliperelman would happily mentor this project as GSoC, Outreachy, or fun side-project.

---
Compared to taskcluster-events this will probably support:
 * one RabbitMQ channel/queue per websocket connection,
 * bind/unbind to exchanges
 * resume/pause
 * automatic reconnection
 * better abuse protection
 * this probably won't handle reconnection without risk of message drops (this would be complicated, with risk of leaking resources in face of crashing nodes) 
  