### PR TITLE
Amend RFC#139 to reduce 40 to 38, omit org/repo

### DIFF
--- a/rfcs/0139-longer-identifiers.md
+++ b/rfcs/0139-longer-identifiers.md
@@ -1,4 +1,4 @@
-# RFC 139 - Increase identifier length from 20 to 44
+# RFC 139 - Increase identifier length from 20 to 38
 * Comments: [#139](https://api.github.com/repos/taskcluster/taskcluster-rfcs/pull/139), [Bug 1520579](https://bugzilla.mozilla.org/show_bug.cgi?id=1520579)
 * Proposed by: @djmitche / @mitchhentges
 
@@ -19,25 +19,42 @@ We can, however, allow more than 22 characters.
 
 We will define two types of identifiers:
 
-* "identifiers" -- up to 40 characters, generally containing human-readable identifiers
+* "identifiers" -- up to 38 characters, generally containing human-readable identifiers
   * `provisionerId`, `workerType`, `workerGroup`, `workerId`
   * `schedulerId`
-  * `organization`, `repository` (in tc-github)
 
 * "slugids" -- exactly 22 characters, always a slugid
   * `taskGroupId`
   * `taskId`
+
+The following remain separate:
+  * `organization`, `repository` (limited to 100 characters in taskcluster-github)
+
+The rationale for the choice of 38 is the [task status routing key](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/references/events#routing-key) which contains
+
+| name           | max characters |
+|----------------|----------------|
+| routingKeyKind | 7              |
+| taskId         | 22             |
+| runId          | 3              |
+| workerGroup    | N              |
+| workerId       | N              |
+| provisionerId  | N              |
+| workerType     | N              |
+| schedulerId    | N              |
+| taskGroupId    | 22             |
+| reserved       | 1              |
+
+With a total of 9 dots between each of those components.
+So the total length is `5N + 55 + 9 <= 255`.
+Solving for N, we get 38. 
 
 This change requires changes to schemas and API declarations in services in the monorepo, as well as to `aws-provisioner` and possibly `ec2-manager`, workers, and client libraries.
 Much of this work has [already been done](https://github.com/taskcluster/taskcluster/pull/110) by @OjaswinM.
 
 We already have checks on AMQP routing key lengths, and the increased length does not cause any failures in that code.
 
-# Open Questions
-
-TBD
-
 # Implementation
 
-* https://github.com/taskcluster/taskcluster/pull/110
-* TBD
+* [taskcluster/taskcluster#110](https://github.com/taskcluster/taskcluster/pull/110)
+* [Bug 1520579](https://bugzilla.mozilla.org/show_bug.cgi?id=1520579)


### PR DESCRIPTION
Once #139 was resolved and Ojas began implementation, it turned out
there were some technical issues with it, not least of which that I had
done the math wrong and 40 characters is too much.  Also, as mentioned
in the PR comments, organization and repository are already allowed to
be 100 characters, so they are removed from consideration here.