### PR TITLE
Update Mechanics

### DIFF
--- a/mechanics.md
+++ b/mechanics.md
@@ -4,63 +4,65 @@ So, how do I use this?
 
 ## I Have an Idea!
 
-Ideas should have
- * a pretty specific goal: a user story ("Users can..."), dependency ("This will allow ..") or a completion condition ("All services .."); and
- * some vague idea of how this might be accomplished, or a few alternatives.
+We've learned that ideas should be developed outside of the RFC process first.
+Create a document in another context and talk it through with the relevant people.
+Keep iterating until there is one option that has rough agreement from those people.
+It's OK if some details are still unclear.
 
-If you have an idea, here's how to get started:
+A symptom of rushing this phase is an enormous list of comments on the RFC pull request.
+This is usually difficult to follow and communications issues quickly swamp the process.
+If this occurs, return to the idea phase.
+
+## I Think We Have Rough Consensus!
+
+By this time you should have:
+
+ * a pretty specific goal: a user story ("Users can..."), dependency ("This will allow ..") or a completion condition ("All services ..");
+ * a pretty solid idea of the solution; and
+ * tentative agreement from most of the people concerned.
+
+It's time to make an RFC!
 
 * Copy [`template.txt`](template.txt) to `rfcs/xxxx-<rfc-title>.md`.
-  Fill in the first few sections, but feel free to leave things TBD at this stage.
-  Commit it to a branch, push, and make a pull request.
+  Be as detailed as possible.
+  If there are open questions, answer them before proceeding.
+  Commit it to a branch, push, and make a *draft* pull request.
 
 * Once you have the pull request number, modify the filename to include it (`rfcs/<number>-<rfc-title>.md`).
   Replace `<number>` in the file with the PR number as well.
-  Push again.
+  Push again, and mark the PR as ready for review, and add the label `Phase: Proposal` to the PR.
 
-You can leave the PR un-assigned, or assign it to yourself if you intend to champion it.
-Shop the issue around to the team and outside the team to try to get a diversity of opinions on it.
-It's OK to leave ideas open indefinitely, awaiting their time.
+* Champion the RFC.
+
+  Get anybody you know will care about this on-board quickly by contacting them
+  by whatever means you want: irc, email, @ mentions should all work well.  As
+  early as possible, get an email out to the tools-tc list if this is going to
+  be something more than a couple specific people care about. Use your best
+  judgement.  Give a few days for opinions to filter in. Respond promptly if
+  possible to avoid a confusing conversation but give enough time for people
+  who are PTO or busy etc.
+
+  The idea here is to work out any disagreement and come to a proposal everyone
+  can live with, so modify the proposal as necessary using the usual git tools.
+  Reaching consensus is unlikely, but compromise is always possible.
 
 ## I Have an Opinion!
 
 Comment on the pull request.
 The Github comments are intended to record the discussion on the idea, so that's the right place.
 
-As the discussion evolves, the assignee will update the Markdown file to match.
+As the discussion evolves, the champion will update the Markdown file to match.
 
 ## Let's Decide!
 
-When everyone is more or less on the same page, it's time to move to the proposal phase.
-
-### Make a Proposal
-
-Fill in the remainder of the template, including lots of details, based on the preceding discussion.
-Push your changes and add the label `Phase: Proposal` to the PR.
-
-### Request Comments
-
-Now get anybody you know will care about this on-board quickly by contacting
-them by whatever means you want: irc, email, @ mentions should all work well.
-As early as possible, get an email out to the tools-tc list if this is going to
-be something more than a couple specific people care about. Use your best
-judgement.  Give a few days for opinions to filter in. Respond promptly if
-possible to avoid a confusing conversation but give enough time for people who
-are PTO or busy etc.  The idea here is to work out any disagreement and come to
-a proposal everyone can live with, so modify the proposal as necessary using
-the usual git tools.  Reaching consensus is unlikely, but compromise is always
-possible.
-
-### Final Comments
-
-When the open questions have been answered and you feel that everyone is on the
+When you feel that everyone is on the
 same page, it's time for the final-comment period.  The intent of this phase is
 to allow someone to speak up and say, "uh, no, that's not what I thought we
 decided as a group" or "I wasn't aware of this proposal, that's crazy", so
 notification should be distributed broadly.  The phase should last long enough
 for everyone to read the summary and speak up, taking into account timezones,
 PTO, and email backlogs - use your best judgement.  This should be at least 24
-hours so that everyone has working-hours to think and respond.
+hours so that everyone has working-hours to think and respond.  A week is typical.
 
 Update the issue's label to `Phase: Final Comment` and send a note summarizing
 the proposal and indicating the duration for comments to the tools-taskcluster

--- a/template.txt
+++ b/template.txt
@@ -12,15 +12,13 @@
 
 # Details
 
-<how will this be implemented? what does it depend on? what are the
-compatibility concerns?
+<how will this be implemented?
+ what does it depend on?
+ what are the compatibility concerns?
+ are there security or performance implications?
+ how will this be implemented?>
 
-# Open Questions
-
-<what isn't decided yet? remove this section when it is empty, and then go to
-the final comment phase>
-
-# Implementation
+# Implementation Links
 
 <once the RFC is decided, these links will provide readers a way to track the
 implementation through to completion>


### PR DESCRIPTION
Mostly: we've learned that ideas should be well-formed before becoming
an RFC.

But this updates some of the remaining mechanics, too, to skip the part
about filing an issue and to take advantage of the new "draft PR"
functionality.