### PR TITLE
Fix some inconsistencies in the proposal

### DIFF
--- a/rfcs/0007-New-Artifact-API.md
+++ b/rfcs/0007-New-Artifact-API.md
@@ -1,5 +1,5 @@
 # RFC 7 - New Artifact API
-* Comments: [#7](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/7)
+* Comments: [#7](https://github.com/taskcluster/taskcluster-rfcs/pull/7)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0008-JSON-e.md
+++ b/rfcs/0008-JSON-e.md
@@ -1,5 +1,5 @@
 # RFC 8 - JSON-e
-* Comments: [#8](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/8)
+* Comments: [#8](https://github.com/taskcluster/taskcluster-rfcs/pull/8)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0009-Switch-to-Auth0-for-authentication-stop-providing-authentication-to-other-services.md
+++ b/rfcs/0009-Switch-to-Auth0-for-authentication-stop-providing-authentication-to-other-services.md
@@ -1,5 +1,5 @@
 # RFC 9 - Switch to Auth0 for authentication, stop providing authentication to other services
-* Comments: [#9](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/9)
+* Comments: [#9](https://github.com/taskcluster/taskcluster-rfcs/pull/9)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0011-Support-QEMU-in-taskcluster-worker.md
+++ b/rfcs/0011-Support-QEMU-in-taskcluster-worker.md
@@ -1,5 +1,5 @@
 # RFC 11 - Support QEMU in taskcluster-worker
-* Comments: [#11](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/11)
+* Comments: [#11](https://github.com/taskcluster/taskcluster-rfcs/pull/11)
 * Initially Proposed by: @djmitche
 
 # Summary

--- a/rfcs/0020-Manage-pulse-credentials-centrally.md
+++ b/rfcs/0020-Manage-pulse-credentials-centrally.md
@@ -1,5 +1,5 @@
 # RFC 20 - Manage pulse credentials centrally
-* Comments: [#20](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/20)
+* Comments: [#20](https://github.com/taskcluster/taskcluster-rfcs/pull/20)
 * Initially Proposed by: @djmitche
 
 # Summary

--- a/rfcs/0021-taskcluster-livelog-proxy-in-production.md
+++ b/rfcs/0021-taskcluster-livelog-proxy-in-production.md
@@ -1,5 +1,5 @@
 # RFC 21 - taskcluster-livelog-proxy in production
-* Comments: [#21](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/21)
+* Comments: [#21](https://github.com/taskcluster/taskcluster-rfcs/pull/21)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0024-Decouple-components-from-routing-mechanisms.md
+++ b/rfcs/0024-Decouple-components-from-routing-mechanisms.md
@@ -1,5 +1,5 @@
 # RFC 24 - Decouple components from routing mechanisms
-* Comments: [#24](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/24)
+* Comments: [#24](https://github.com/taskcluster/taskcluster-rfcs/pull/24)
 * Initially Proposed by: @eliperelman
 
 # Proposal

--- a/rfcs/0027-Migrate-unified-logviewer-to-a-standalone-React-component.md
+++ b/rfcs/0027-Migrate-unified-logviewer-to-a-standalone-React-component.md
@@ -1,5 +1,5 @@
 # RFC 27 - Migrate unified-logviewer to a standalone React component
-* Comments: [#27](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/27)
+* Comments: [#27](https://github.com/taskcluster/taskcluster-rfcs/pull/27)
 * Initially Proposed by: @eliperelman
 
 # Proposal

--- a/rfcs/0034-Audit-logging.md
+++ b/rfcs/0034-Audit-logging.md
@@ -1,5 +1,5 @@
 # RFC 34 - Audit logging
-* Comments: [#34](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/34)
+* Comments: [#34](https://github.com/taskcluster/taskcluster-rfcs/pull/34)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0035-structured-logging.md
+++ b/rfcs/0035-structured-logging.md
@@ -1,5 +1,5 @@
 # RFC 35 - Structured Logging
-* Comments: [#35](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/35)
+* Comments: [#35](https://github.com/taskcluster/taskcluster-rfcs/pull/35)
 * Proposed by: @jhford (originator), @djmitche, @imbstack (author of this document)
 
 # Summary

--- a/rfcs/0043-Get-rid-of-tc-vcs-completely.md
+++ b/rfcs/0043-Get-rid-of-tc-vcs-completely.md
@@ -1,5 +1,5 @@
 # RFC 43 - Get rid of tc-vcs completely
-* Comments: [#43](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/43)
+* Comments: [#43](https://github.com/taskcluster/taskcluster-rfcs/pull/43)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0044-Get-rid-of-gaia-taskcluster.md
+++ b/rfcs/0044-Get-rid-of-gaia-taskcluster.md
@@ -1,5 +1,5 @@
 # RFC 44 - Get rid of gaia-taskcluster
-* Comments: [#44](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/44)
+* Comments: [#44](https://github.com/taskcluster/taskcluster-rfcs/pull/44)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0048-Parameterized-Roles.md
+++ b/rfcs/0048-Parameterized-Roles.md
@@ -1,5 +1,5 @@
 # RFC 48 - Parameterized Roles
-* Comments: [#48](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/48)
+* Comments: [#48](https://github.com/taskcluster/taskcluster-rfcs/pull/48)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0053-Use-a-git-repository-for-retrospectives.md
+++ b/rfcs/0053-Use-a-git-repository-for-retrospectives.md
@@ -1,5 +1,5 @@
 # RFC 53 - Use a git repository for retrospectives
-* Comments: [#53](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/53)
+* Comments: [#53](https://github.com/taskcluster/taskcluster-rfcs/pull/53)
 * Initially Proposed by: @imbstack
 
 # Proposal

--- a/rfcs/0057-Refresh-the-manual-as-a-readable-well-manual-for-taskcluster.md
+++ b/rfcs/0057-Refresh-the-manual-as-a-readable-well-manual-for-taskcluster.md
@@ -1,5 +1,5 @@
 # RFC 57 - Refresh the manual as a readable .. well, manual for taskcluster
-* Comments: [#57](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/57)
+* Comments: [#57](https://github.com/taskcluster/taskcluster-rfcs/pull/57)
 * Initially Proposed by: @djmitche
 
 

--- a/rfcs/0058-Add-more-task-priority-levels.md
+++ b/rfcs/0058-Add-more-task-priority-levels.md
@@ -1,5 +1,5 @@
 # RFC 58 - Add more `task.priority` levels
-* Comments: [#58](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/58)
+* Comments: [#58](https://github.com/taskcluster/taskcluster-rfcs/pull/58)
 * Initially Proposed by: @jonasfj
 
 # Proposal

--- a/rfcs/0065-Migrate-queue-to-postgres.md
+++ b/rfcs/0065-Migrate-queue-to-postgres.md
@@ -1,5 +1,5 @@
 # RFC 65 - Migrate queue to postgres
-* Comments: [#65](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/65)
+* Comments: [#65](https://github.com/taskcluster/taskcluster-rfcs/pull/65)
 * Initially Proposed by: @jonasfj
 
 # Summary

--- a/rfcs/0066-Allow-hooks-to-be-triggered-by-pulse-messages.md
+++ b/rfcs/0066-Allow-hooks-to-be-triggered-by-pulse-messages.md
@@ -1,5 +1,5 @@
 # RFC 66 - Allow hooks to be triggered by pulse messages
-* Comments: [#66](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/66)
+* Comments: [#66](https://github.com/taskcluster/taskcluster-rfcs/pull/66)
 * Initially Proposed by: @djmitche
 
 # Summary

--- a/rfcs/0074-Worker-workerType-and-provisioner-explorer-UI.md
+++ b/rfcs/0074-Worker-workerType-and-provisioner-explorer-UI.md
@@ -1,5 +1,5 @@
 # RFC 74 - Worker, workerType, and provisioner explorer UI
-* Comments: [#74](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/74)
+* Comments: [#74](https://github.com/taskcluster/taskcluster-rfcs/pull/74)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0075-Miscellaneous-Workers.md
+++ b/rfcs/0075-Miscellaneous-Workers.md
@@ -1,5 +1,5 @@
 # RFC 75 - Miscellaneous Workers
-* Comments: [#75](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/75)
+* Comments: [#75](https://github.com/taskcluster/taskcluster-rfcs/pull/75)
 * Initially Proposed by: @djmitche
 
 

--- a/rfcs/0076-Turn-off-the-scheduler-service.md
+++ b/rfcs/0076-Turn-off-the-scheduler-service.md
@@ -1,5 +1,5 @@
 # RFC 76 - Turn off the scheduler service
-* Comments: [#76](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/76)
+* Comments: [#76](https://github.com/taskcluster/taskcluster-rfcs/pull/76)
 * Initially Proposed by: @djmitche
 
 # Summary

--- a/rfcs/0080-store-RFCs-in-files-in-the-repository-discuss-RFC-through-a-PR.md
+++ b/rfcs/0080-store-RFCs-in-files-in-the-repository-discuss-RFC-through-a-PR.md
@@ -1,5 +1,5 @@
 # RFC 80 - store RFCs in files in the repository, discuss RFC through a PR
-* Comments: [#80](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/80)
+* Comments: [#80](https://github.com/taskcluster/taskcluster-rfcs/pull/80)
 * Initially Proposed by: @jhford
 
 # Proposal

--- a/rfcs/0082-Users-should-be-able-to-administer-workers-across-provisioner-boundaries.md
+++ b/rfcs/0082-Users-should-be-able-to-administer-workers-across-provisioner-boundaries.md
@@ -1,5 +1,5 @@
 # RFC 82 - Users should be able to administer workers across provisioner boundaries
-* Comments: [#82](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/82)
+* Comments: [#82](https://github.com/taskcluster/taskcluster-rfcs/pull/82)
 * Initially Proposed by: @gregarndt
 
 # Proposal

--- a/rfcs/0086-Stage-2-provisioner-workerType-and-worker-metadata-endpoints.md
+++ b/rfcs/0086-Stage-2-provisioner-workerType-and-worker-metadata-endpoints.md
@@ -1,5 +1,5 @@
 # RFC 86 - Stage 2: provisioner, workerType, and worker metadata endpoints
-* Comments: [#86](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/86)
+* Comments: [#86](https://github.com/taskcluster/taskcluster-rfcs/pull/86)
 * Initially Proposed by: @helfi92
 
 # Proposal

--- a/rfcs/0087-Actively-manage-AWS-resources.md
+++ b/rfcs/0087-Actively-manage-AWS-resources.md
@@ -1,5 +1,5 @@
 # RFC 87 - Actively manage AWS resources
-* Comments: [#87](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/87)
+* Comments: [#87](https://github.com/taskcluster/taskcluster-rfcs/pull/87)
 * Initially Proposed by: @djmitche
 
 # Proposal

--- a/rfcs/0090-Disabling-enabling-a-worker.md
+++ b/rfcs/0090-Disabling-enabling-a-worker.md
@@ -1,5 +1,5 @@
 # RFC 90 - Disabling/enabling a worker
-* Comments: [#90](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/90)
+* Comments: [#90](https://github.com/taskcluster/taskcluster-rfcs/pull/90)
 * Initially Proposed by: @helfi92
 
 # Proposal

--- a/rfcs/0091-Store-infra-configuration-in-a-distinct-repo-that-does-not-ride-trains.md
+++ b/rfcs/0091-Store-infra-configuration-in-a-distinct-repo-that-does-not-ride-trains.md
@@ -1,5 +1,5 @@
 # RFC 91 - Store infra configuration in a distinct repo that does not ride trains
-* Comments: [#91](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/91)
+* Comments: [#91](https://github.com/taskcluster/taskcluster-rfcs/pull/91)
 * Initially Proposed by: @djmitche
 
 

--- a/rfcs/0097-Provisioner-worker-type-worker-actions.md
+++ b/rfcs/0097-Provisioner-worker-type-worker-actions.md
@@ -1,5 +1,5 @@
 # RFC 97 - Provisioner, worker-type & worker actions
-* Comments: [#97](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/97)
+* Comments: [#97](https://github.com/taskcluster/taskcluster-rfcs/pull/97)
 * Initially Proposed by: @helfi92
 
 # Proposal

--- a/rfcs/0110-Best-practices-for-testing-and-credentials.md
+++ b/rfcs/0110-Best-practices-for-testing-and-credentials.md
@@ -1,5 +1,5 @@
 # RFC 110 - Best Practices for testing and Credentials
-* Comments: [#110](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/110)
+* Comments: [#110](https://github.com/taskcluster/taskcluster-rfcs/pull/110)
 * Proposed by: @djmitche
 
 # Summary

--- a/rfcs/0120-artifact-service.md
+++ b/rfcs/0120-artifact-service.md
@@ -1,5 +1,5 @@
 # RFC 120 object Service
-* Comments: [#120](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/120)
+* Comments: [#120](https://github.com/taskcluster/taskcluster-rfcs/pull/120)
 * Proposed by: @jhford
 
 # Summary

--- a/rfcs/0124-worker-manager.md
+++ b/rfcs/0124-worker-manager.md
@@ -1,5 +1,5 @@
 # RFC 124 - Worker Manager
-* Comments: [#124](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/124)
+* Comments: [#124](https://github.com/taskcluster/taskcluster-rfcs/pull/124)
 * Proposed by: @jhford
 
 # Summary

--- a/rfcs/0128-redeployable-clients.md
+++ b/rfcs/0128-redeployable-clients.md
@@ -1,6 +1,6 @@
 # RFC 0128 - Service metadata in redeployable taskcluster
 
-* Comments: [#128](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/128)
+* Comments: [#128](https://github.com/taskcluster/taskcluster-rfcs/pull/128)
 * Proposed by: @petemoore
 
 # Table of contents

--- a/rfcs/0131-Implementing Checks API in tc-github while preserving Statuses API.md
+++ b/rfcs/0131-Implementing Checks API in tc-github while preserving Statuses API.md
@@ -1,5 +1,5 @@
 # RFC 131 - Implementing Checks API
-* Comments: [#130](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/130)
+* Comments: [#130](https://github.com/taskcluster/taskcluster-rfcs/pull/130)
 * Proposed by: @djmitche, @owlishDeveloper (author of this document)
 
 # Summary

--- a/rfcs/0136-scope-expression-registration.md
+++ b/rfcs/0136-scope-expression-registration.md
@@ -1,5 +1,5 @@
 # RFC 136 - Scope Expression Registration
-* Comments: [#136](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/136)
+* Comments: [#136](https://github.com/taskcluster/taskcluster-rfcs/pull/136)
 * Proposed by: @imbstack
 
 # Summary

--- a/rfcs/0147-third-party-login.md
+++ b/rfcs/0147-third-party-login.md
@@ -1,5 +1,5 @@
 # RFC 147 - Third-Party Login
-* Comments: [#147](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/147)
+* Comments: [#147](https://github.com/taskcluster/taskcluster-rfcs/pull/147)
 * Proposed by: @djmitche
 
 # Background
@@ -59,7 +59,6 @@ The page presents the requested information to the user for consent, and then re
 
 ## Requirements
 
-* Support command-line logins
 * Support third-party logins
 * Support issuing limited-authorization credentials
 * Support whitelisting some third parties
@@ -78,7 +77,7 @@ The result is similar to a normal OAuth authorization-code flow, but resulting i
 ## Implementation
 
 The "big picture" here is that a Taskcluster deployment acts as an OAuth2 authorization server and resource server.
-The "resource" that the deployment protects is temporary Taskcluster credentials.
+The "resource" that the deployment protects is Taskcluster credentials.
 Thus a client carries out a standard OAuth2 authorization transaction, then uses the resulting `access_token` to request Taskcluster credentials as needed.
 
 The deviations from OAuth2 are as follows:
@@ -212,6 +211,8 @@ The `expires` property gives the expiration time for the given credentials, and 
 The client indicated in the credentials has the clientId described above, and as such is scanned periodically for alignment with the associated user's access.
 It will be automatically disabled if the user's access no longer satisfies its scopes.
 The client can also be disabled or deleted manually in the event of compromise.
+
+This endpoint does not produce temporary credentials, as such credentials are not revocable.
 
 ## Transition Period
 

--- a/template.txt
+++ b/template.txt
@@ -1,5 +1,5 @@
 # RFC <number> - <title>
-* Comments: [#<number>](https://api.github.com/repos/taskcluster/taskcluster-rfcs/issues/<number>)
+* Comments: [#<number>](https://github.com/taskcluster/taskcluster-rfcs/pull/<number>)
 * Proposed by: @<yourname>
 
 # Summary


### PR DESCRIPTION
None of these materially change the proposal, but clarify its meaning

 * fix PR link in header
 * remove command-line logins as a requirement (since it's not met)
 * remove mention of temporary credentials in "big picture"
 * include a sentence confirming that the resulting credentials are not temporary (this was already implicit)

This does *not* address some deviations from the proposal being made in the implementation (which are fine, just shouldn't be reflected here).