### PR TITLE
RFC: Add scopes for anonymous calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ See [mechanics](mechanics.md) for more detail.
 | RFC#154 | [Migrate Taskcluster to postgres](rfcs/0154-Migrate-taskcluster-to-postgres.md)                                                                                                        |
 | RFC#155 | [Create an object service](rfcs/Create-object-service.md)                                                                                                                              |
 | RFC#163 | [ProjectId](rfcs/0163-project-id.md)                                                                                                                                                   |
+| RFC#165 | [Anonymous scopes](rfcs/0165-Anonymous-scopes.md)                                                                                                                                      |
 | RFC#166 | [Sign Public S3 URLs](rfcs/0166-Sign-public-S3-urls.md)                                                                                                                                |

--- a/rfcs/0165-Anonymous-scopes.md
+++ b/rfcs/0165-Anonymous-scopes.md
@@ -19,7 +19,7 @@ credentials.
 A single scope will be assumed for all calls (with or without credentials):
 `assume:anonymous`. A new API call will be added to the auth service
 (`authenticateAnonymous`) which will return `{"scopes":...,"expiry":...}`.
-The authentication middleware will call `authenticateAnonymous` but cache the
+The authentication middleware in each service will call `authenticateAnonymous` but cache the
 result until `expiry`. A deploy-time variable will be added (`auth.scopes_ttl`)
 which configures how long the auth service declares looked up scopes to be
 valid. 

--- a/rfcs/0165-Anonymous-scopes.md
+++ b/rfcs/0165-Anonymous-scopes.md
@@ -28,7 +28,7 @@ areas:
 - All API calls which currently require no scopes will be given explicit
   required scopes, ideally matching their counterparts already with required
   scopes. These exact scopes will be decided at implementation time.
-- The authentication middleware in `taskcluster-lib-api` used by all services
+- The authentication middleware in `taskcluster-lib-api`, used by all services,
   will no longer early out if there are no authorization headers.
 - The remote signature validator (used by all services except the auth service)
   will call `authenticateAnonymous` if no authorization headers are passed.
@@ -49,7 +49,7 @@ areas:
 - Scopes will be expanded every call, this will cause additional overhead for
   anonymous calls.
 - There will need to be some kind of migration to ensure that public
-  clusters automatically inherit the view scopes for all calls.
+  clusters automatically inherit the new scopes for all calls.
   - This could be done as a database migration, inserting all added required
     scopes to the anonymous role as all Taskcluster installations older than
     this change will be assumed to be public.

--- a/rfcs/0165-Anonymous-scopes.md
+++ b/rfcs/0165-Anonymous-scopes.md
@@ -10,39 +10,68 @@ Additionally, we will move all API calls behind at least one scope.
 
 ## Motivation
 
-This is primarily aimed at private TaskCluster installations. With this, it will
-be possible to prevent any useful access to the TaskCluster installation without
+This is primarily aimed at private Taskcluster installations. With this, it will
+be possible to prevent any useful access to the Taskcluster installation without
 credentials.
+
+This RFC doesn't propose changes to the UI as it's considered part of a minimal
+path towards private Taskcluster installations and inoperative UI when not
+logged in is acceptable.
 
 # Details
 ## Implementation
 A single scope will be assumed for all calls (with or without credentials):
-`assume:anonymous`. A new API call will be added to the auth service
-(`authenticateAnonymous`) which will return `{"scopes":...,"expiry":...}`.
-The authentication middleware in each service will call `authenticateAnonymous` but cache the
-result until `expiry`. A deploy-time variable will be added (`auth.scopes_ttl`)
-which configures how long the auth service declares looked up scopes to be
-valid. 
-
-All API calls which currently require no scopes will require
-`<service-name>:view`. This leaves room to add more specific scopes at a later
-date.
+`assume:anonymous`. In order to implement this, changes will be made in a few
+areas:
+- A new API call will be added to the auth service (`authenticateAnonymous`)
+  which will return the expanded scopes of `["assume:anonymous"]`.
+- All API calls which currently require no scopes will be given explicit
+  required scopes, ideally matching their counterparts already with required
+  scopes. These exact scopes will be decided at implementation time.
+- The authentication middleware in `taskcluster-lib-api` used by all services
+  will no longer early out if there are no authorization headers.
+- The remote signature validator (used by all services except the auth service)
+  will call `authenticateAnonymous` if no authorization headers are passed.
+- The auth service signature validator will be changed to return the scopes
+  expanded from `["assume:anonymous"]` if no credentials are passed.
+- The auth service signature validator will include the expanded anonymous
+  scopes when using credentials **after** applying scope restriction.
+- The API builder in `taskcluster-lib-api` will be changed to assert that
+  at least one scope is required except for endpoints which explicity opt-out
+  (which should be just `authenticateHawk` and `authenticateAnonymous`).
+- `expandScopes` will **not** be changed to include the anonymous role as this
+  is then within the power of the caller.
+- Add `assume:anonymous` to the scopes returned by `User::scopes` in
+  `web-server`. (This is adding an assumption about the anonymous role but
+  a similar assumption is made about `assume:login-identity:` already).
 
 ## Drawbacks
 - Scopes will be expanded every call, this will cause additional overhead for
-  anonymous calls
-  - This is largely mitigated by caching the anonymous scopes, even a relatively
-    small TTL (such as 10 seconds) is enough to mitigate the brunt of the cost.
+  anonymous calls.
 - There will need to be some kind of migration to ensure that public
   clusters automatically inherit the view scopes for all calls.
-  - This could be done as a database migration, inserting `:view` for each
-    service under `assume:anonymous`.
+  - This could be done as a database migration, inserting all added required
+    scopes to the anonymous role as all Taskcluster installations older than
+    this change will be assumed to be public.
 
 ## Alternatives
-- Instead of the `expiry` field, add a config variable to all services which
-  controls this.
-  - This would make the change more sweeping.
-- Instead of the `authenticateAnonymous` endpoint, add an `expiry` field to
-  `expandScopes` in order to know how long to cache the anonymous scopes.
+- Instead of the `authenticateAnonymous` endpoint, allow the `authenticateHawk`
+  endpoint to accept requests with no hawk/bewit credentials and return just
+  the anonymous scopes.
+- Instead of adding `authenticateAnonymous`, allow the `authenticateHawk`
+  endpoint to return the anonymous scopes when the authorization parameters
+  are missing.
+- Instead of including `assume:anonymous` in `authenticateHawk` and calling
+  `authenticateAnonymous` at the signature validation stage, alter the
+  `taskcluster-lib-api` auth middleware to include the anonymous scopes before
+  testing the scope expression.
+- When adding anonymous scopes to calls with credentials, add them **before**
+  restriction, so that anonymous scopes can be restricted. This will require
+  additional migration effort but may reduce the surprise compared to the
+  preferred implementation.
+
+## Future considerations
+This RFC will introduce more load on the auth service. With the preferred
+implementation it should be quite easy to add caching in a later RFC.
 
 # Implementation

--- a/rfcs/0165-Anonymous-scopes.md
+++ b/rfcs/0165-Anonymous-scopes.md
@@ -1,0 +1,48 @@
+# RFC 165 - Anonymous scopes
+* Comments: [#165](https://github.com/taskcluster/taskcluster-rfcs/pull/165)
+* Proposed by: @ricky26
+
+# Summary
+
+We currently assign no scopes to calls with no credentials. With this proposal
+we would assign a single role to all calls and any scopes expanded from that.
+Additionally, we will move all API calls behind at least one scope.
+
+## Motivation
+
+This is primarily aimed at private TaskCluster installations. With this, it will
+be possible to prevent any useful access to the TaskCluster installation without
+credentials.
+
+# Details
+## Implementation
+A single scope will be assumed for all calls (with or without credentials):
+`assume:anonymous`. A new API call will be added to the auth service
+(`authenticateAnonymous`) which will return `{"scopes":...,"expiry":...}`.
+The authentication middleware will call `authenticateAnonymous` but cache the
+result until `expiry`. A deploy-time variable will be added (`auth.scopes_ttl`)
+which configures how long the auth service declares looked up scopes to be
+valid. 
+
+All API calls which currently require no scopes will require
+`<service-name>:view`. This leaves room to add more specific scopes at a later
+date.
+
+## Drawbacks
+- Scopes will be expanded every call, this will cause additional overhead for
+  anonymous calls
+  - This is largely mitigated by caching the anonymous scopes, even a relatively
+    small TTL (such as 10 seconds) is enough to mitigate the brunt of the cost.
+- There will need to be some kind of migration to ensure that public
+  clusters automatically inherit the view scopes for all calls.
+  - This could be done as a database migration, inserting `:view` for each
+    service under `assume:anonymous`.
+
+## Alternatives
+- Instead of the `expiry` field, add a config variable to all services which
+  controls this.
+  - This would make the change more sweeping.
+- Instead of the `authenticateAnonymous` endpoint, add an `expiry` field to
+  `expandScopes` in order to know how long to cache the anonymous scopes.
+
+# Implementation

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -46,4 +46,5 @@
 | RFC#154 | [Migrate Taskcluster to postgres](0154-Migrate-taskcluster-to-postgres.md)                                                                                                        |
 | RFC#155 | [Create an object service](Create-object-service.md)                                                                                                                              |
 | RFC#163 | [ProjectId](0163-project-id.md)                                                                                                                                                   |
+| RFC#165 | [Anonymous scopes](0165-Anonymous-scopes.md)                                                                                                                                      |
 | RFC#166 | [Sign Public S3 URLs](0166-Sign-public-S3-urls.md)                                                                                                                                |


### PR DESCRIPTION
An RFC to allow controlling access to all API endpoints in the TaskCluster services.