### PR TITLE
RFC: Untrusted pull request roles based on author's association

### DIFF
--- a/rfcs/0170-author-association-for-PRs.md
+++ b/rfcs/0170-author-association-for-PRs.md
@@ -1,0 +1,59 @@
+# RFC 170 - Author Association Roles for Github Pull Requests
+
+# Summary
+
+Assume different roles for Github Pull Requests based on the PR author's association to the project.
+
+## Motivation
+
+Currently Taskcluster's [pullRequest policy][0] is very basic. It can either generate graphs for
+everyone, or only for collaborators. If a project has a task that can access secrets or perform
+actions that shouldn't be triggered publicly, then the only recourse is to not generate *any* graph
+so long as the author is not at least a collaborator.
+
+However, projects commonly have non-sensitive tasks that *could* otherwise be run publicly. Having
+distinct roles based on author association would allow projects to generate graphs for public pull
+requests, while simultaneously blocking these graphs from running sensitive tasks via scopes.
+
+The motivations for this RFC overlap with [RFC 168][1].
+
+# Details
+
+A new `pullRequest` policy called `public_restricted` will be invented. When used, Taskcluster
+Github will inspect the author association of the pull request to determine whether or not they are
+a collaborator. If they are determined to be a collaborator, the current [pull-request][2] role will
+be assumed. So far this behavior is identical to the `collaborators` policy.
+
+However if the author is not a collaborator, a new role called `repo:github.com/${
+payload.organization }/${ payload.repository }:pull-request-untrusted` will be assumed instead.
+
+To allow projects to tell whether a pull request was created by a collaborator or not, a new
+`is_collaborator` field will be included in the JSON-e context used to evaluate the
+`.taskcluster.yml` file. This field will be present when `tasks_for` is `github-pull-request`
+(regardless of `pullRequest` policy), otherwise it will be undefined.
+
+## Using the `public_restricted` policy
+
+Using the `public_restricted` policy will require that both the Taskcluster instance and the project
+are configured properly. While the details around this configuration are out of scope for this RFC,
+it's worth providing a brief example to help illustrate how the feature might be used.
+
+### Instance Configuration
+
+Taskcluster administrators will need to ensure the `pull-request-untrusted` roles exist for any
+projects that use the `public_restricted` policy. They'll also need to ensure that scopes are
+properly assigned to block running any sensitive tasks on untrusted pull requests.
+
+### Task Configuration
+
+Projects that use the `public_restricted` policy will need to make sure they don't try to run
+trusted tasks on untrusted PRs, otherwise they'll get a scope expression error. They'll be able to
+accomplish this via the `is_collaborator` field that Taskcluster Github now passes down to the
+JSON-e context.
+
+In the case of a plain `.taskcluster.yml` file, this value could be used in a JSON-e conditional
+statement. In the case of Taskgraph, this could be passed in via a new parameter.
+
+[0]: https://docs.taskcluster.net/docs/reference/integrations/github/taskcluster-yml-v1#pull-requests
+[1]: https://github.com/taskcluster/taskcluster-rfcs/blob/main/rfcs/0168-Trigger-Tests-Based-on-PR-Comments.md
+[2]: https://github.com/taskcluster/taskcluster/blob/b31b890043847059c2d09dc7e2428814b9b51c0b/services/github/src/tc-yaml.js#L184

--- a/rfcs/0170-author-association-for-PRs.md
+++ b/rfcs/0170-author-association-for-PRs.md
@@ -28,9 +28,8 @@ However if the author is not a collaborator, a new role called `repo:github.com/
 payload.organization }/${ payload.repository }:pull-request-untrusted` will be assumed instead.
 
 To allow projects to tell whether a pull request was created by a collaborator or not, a new
-`is_collaborator` field will be included in the JSON-e context used to evaluate the
-`.taskcluster.yml` file. This field will be present when `tasks_for` is `github-pull-request`
-(regardless of `pullRequest` policy), otherwise it will be undefined.
+`tasks_for` value of `github-pull-request-untrusted` will be used to evaluate the
+`.taskcluster.yml` file.
 
 ## Using the `public_restricted` policy
 
@@ -48,8 +47,8 @@ properly assigned to block running any sensitive tasks on untrusted pull request
 
 Projects that use the `public_restricted` policy will need to make sure they don't try to run
 trusted tasks on untrusted PRs, otherwise they'll get a scope expression error. They'll be able to
-accomplish this via the `is_collaborator` field that Taskcluster Github now passes down to the
-JSON-e context.
+accomplish this by inspecting the `tasks_for` field that Taskcluster Github now passes down to the
+JSON-e context and checking for a value of `github-pull-request-untrusted`.
 
 In the case of a plain `.taskcluster.yml` file, this value could be used in a JSON-e conditional
 statement. In the case of Taskgraph, this could be passed in via a new parameter.

--- a/rfcs/0175-restricted-pull-requests.md
+++ b/rfcs/0175-restricted-pull-requests.md
@@ -1,4 +1,4 @@
-# RFC 170 - Author Association Roles for Github Pull Requests
+# RFC 175 - Restricted Roles for Github Pull Requests
 
 # Summary
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -51,3 +51,4 @@
 | RFC#166 | [Sign Public S3 URLs](0166-Sign-public-S3-urls.md)                                                                                                                                |
 | RFC#168 | [Process Github issue_comment events to support adhoc task creation](0168-Trigger-Tests-Based-on-PR-Comments.md)                                                                  |
 | RFC#169 | [Easy Taskcluster Setup](0169-Easy-Taskcluster-setup.md)                                                                                                                          |
+| RFC#175 | [Restricted Pull Requests](0175-restricted-pull-requests.md)                                                                                                                          |


### PR DESCRIPTION
[Rendered](https://github.com/ahal/taskcluster-rfcs/blob/github_author_association/rfcs/0175-restricted-pull-requests.md)

Issue: #173