### PR TITLE
Start discussion for auto-cancel functionality in github service

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ See [mechanics](mechanics.md) for more detail.
 | RFC#169 | [Easy Taskcluster Setup](rfcs/0169-Easy-Taskcluster-setup.md)                                                                                                                          |
 | RFC#175 | [Restricted Roles for Github Pull Requests](rfcs/0175-restricted-pull-requests.md)                                                                                                     |
 | RFC#177 | [Skip CI in github integration](rfcs/0177-Skip-ci-integrations.md)                                                                                                                     |
+| RFC#180 | [Github cancel previous tasks](rfcs/0180-Github-cancel-previous-tasks.md)                                                                                                              |

--- a/rfcs/0180-Github-cancel-previous-tasks.md
+++ b/rfcs/0180-Github-cancel-previous-tasks.md
@@ -15,6 +15,8 @@ By cancelling previous task groups and tasks we could save significant amount of
 
 # Details
 
+## Github hooks
+
 This will only apply to non-default branches (and possible protected branches?),
 to allow all pushes to the default branch to have their own builds.
 
@@ -25,6 +27,11 @@ Github's webhook handler upon receiving `push` event would check if there are ot
 If `authCancelPreviousChecks` is set to `true` it will cancel them.
 
 Cancellation will happen for all the non-resolved tasks within the same `taskGroupId`. However, due to the fact that tasks can create their own sub-tasks, there might be cases where running tasks would still manage to create some tasks that might not be cancelled.
+
+## Github API
+
+To make it easier for developers to cancel running builds associated with some specific branch we can expose new API endpoint. `github.cancelBuilds({ organization, repository, branch })` would be able to find all task groups associated with this branch, find all non-resolved tasks within those groups and cancel those.
+
 
 # Implementation
 

--- a/rfcs/0180-Github-cancel-previous-tasks.md
+++ b/rfcs/0180-Github-cancel-previous-tasks.md
@@ -1,0 +1,29 @@
+# RFC 180 - Github cancel previous tasks
+* Comments: [#180](https://github.com/taskcluster/taskcluster-rfcs/pull/180)
+* Proposed by: @lotas
+
+# Summary
+
+Allow to automatically cancel previous pipelines for github push and pull_request events.
+
+## Motivation
+
+This will allow to save computing resources and give more flexibility for the Taskcluster users on Github.
+When several pushes happen to the same branch within a short amount of time, like hotfixes or rebases,
+only the last commit and pipelines matters.
+By cancelling previous task groups and tasks we could save significant amount of redundant tasks.
+
+# Details
+
+This will only apply to non-default branches (and possible protected branches?),
+to allow all pushes to the default branch to have their own builds.
+
+To be flexible and allow some projects to still run checks for all events, we could add new key to the `.taskcluster.yml` configuration.
+We can introduce top-level configuration option `autoCancel: true` (having `false` by default) to control if this behaviour is desired.
+
+Github's webhook handler upon receiving `push` event would check if there are other task groups existing for given branch, that are not HEAD.
+If `autoCancel` is set to `true` it will cancel them (Do we need to cancel all tasks in group one by one or just the parent decision task?)
+
+# Implementation
+
+* Original request issue [#5621](https://github.com/taskcluster/taskcluster/issues/5621)

--- a/rfcs/0180-Github-cancel-previous-tasks.md
+++ b/rfcs/0180-Github-cancel-previous-tasks.md
@@ -4,14 +4,14 @@
 
 # Summary
 
-Allow to automatically cancel previous pipelines for github push and pull_request events.
+Allow to automatically cancel previous pipelines for github `push` and `pull_request` events.
 
 ## Motivation
 
 This will allow to save computing resources and give more flexibility for the Taskcluster users on Github.
 When several pushes happen to the same branch within a short amount of time, like hotfixes or rebases,
 only the last commit and pipelines matters.
-By cancelling previous task groups and tasks we could save significant amount of redundant tasks.
+By cancelling previous task groups and tasks we could save significant amount of compute resources and developer hours by not running redundant tasks.
 
 # Details
 
@@ -19,10 +19,12 @@ This will only apply to non-default branches (and possible protected branches?),
 to allow all pushes to the default branch to have their own builds.
 
 To be flexible and allow some projects to still run checks for all events, we could add new key to the `.taskcluster.yml` configuration.
-We can introduce top-level configuration option `autoCancel: true` (having `false` by default) to control if this behaviour is desired.
+We can introduce top-level configuration option `authCancelPreviousChecks: true` (having `true` by default) to control if this behaviour is desired.
 
 Github's webhook handler upon receiving `push` event would check if there are other task groups existing for given branch, that are not HEAD.
-If `autoCancel` is set to `true` it will cancel them (Do we need to cancel all tasks in group one by one or just the parent decision task?)
+If `authCancelPreviousChecks` is set to `true` it will cancel them.
+
+Cancellation will happen for all the non-resolved tasks within the same `taskGroupId`. However, due to the fact that tasks can create their own sub-tasks, there might be cases where running tasks would still manage to create some tasks that might not be cancelled.
 
 # Implementation
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -53,3 +53,4 @@
 | RFC#169 | [Easy Taskcluster Setup](0169-Easy-Taskcluster-setup.md)                                                                                                                          |
 | RFC#175 | [Restricted Roles for Github Pull Requests](0175-restricted-pull-requests.md)                                                                                                     |
 | RFC#177 | [Skip CI in github integration](0177-Skip-ci-integrations.md)                                                                                                                     |
+| RFC#180 | [Github cancel previous tasks](0180-Github-cancel-previous-tasks.md)                                                                                                              |


### PR DESCRIPTION
Rendered file: [rfcs/0180-Github-cancel-previous-tasks.md](https://github.com/taskcluster/taskcluster-rfcs/blob/2e985456415e26b9e1aca254aedb038ecc0c2f5e/rfcs/0180-Github-cancel-previous-tasks.md)