### PR TITLE
Add note about running maketoc.py as part of RFC filing process

### DIFF
--- a/mechanics.md
+++ b/mechanics.md
@@ -30,6 +30,7 @@ It's time to make an RFC!
 
 * Once you have the pull request number, modify the filename to include it (`rfcs/<number>-<rfc-title>.md`).
   Replace `<number>` in the file with the PR number as well.
+  Run `maketoc.py` to update the READMEs.
   Push again, and mark the PR as ready for review, and add the label `Phase: Proposal` to the PR.
 
 * Champion the RFC.


### PR DESCRIPTION
It looks like this is a mandatory step given that CI fails if you don't do it? (Unless the idea is that it is that it's only done after an RFC is accepted...)