### PR TITLE
Fix RFC 168 to match what got implemented

### DIFF
--- a/rfcs/0168-Trigger-Tests-Based-on-PR-Comments.md
+++ b/rfcs/0168-Trigger-Tests-Based-on-PR-Comments.md
@@ -16,7 +16,7 @@ As Taskcluster is used increasingly for high-importance projects on Github (like
 
 # Details
 
-`.taskcluster.yml` will be modified to support a new `allowComments` policy, which will support `collaborators` as a value. When set, collaborators to the repository may add a comment containing a string beginning with "/taskcluster ", which will cause Taskcluster-Github to render `.taskcluster.yml` with `tasks_for` set to `github-issue-comment`, and a new context variable `event.issue.comment` set to everything appearing after "/taskcluster " in the comment. For example, a comment of "/taskcluster run-tests" will set `event.comment` to `run-tests`. This will allow `.taskcluster.yml` implementers the flexibility to take different actions based on the comment. Some examples:
+`.taskcluster.yml` will be modified to support a new `allowComments` policy, which will support `collaborators` as a value. When set, collaborators to the repository may add a comment containing a string beginning with "/taskcluster ", which will cause Taskcluster-Github to render `.taskcluster.yml` with `tasks_for` set to `github-issue-comment`, and a new context variable `event.taskcluster_comment` set to everything appearing after "/taskcluster " in the comment. For example, a comment of "/taskcluster run-tests" will set `event.taskcluster_comment` to `run-tests`. This will allow `.taskcluster.yml` implementers the flexibility to take different actions based on the comment. Some examples:
 * A comment of "/taskcluster run-tests" could trigger all Tasks
 * A comment of "/taskcluster run-test-foo" could trigger just the `foo` Task
 * A comment of "/taskcluster merge" could trigger a Task that merges the PR


### PR DESCRIPTION
First, this sentence was contradicting itself, one part was saying `event.issue.comment`, the other `event.comment`. Second, this got implemented as `event.taskcluster_comment` instead. See https://github.com/taskcluster/taskcluster/blob/76fd9d8417f6de65db5611878dd60e21e5782658/services/github/src/handlers/job.js#L218