### PR TITLE
TaskCluster -> Taskcluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TaskCluster RFCs
+# Taskcluster RFCs
 
 
 ## Background


### PR DESCRIPTION
A _long_ time ago we decided to exclusively write Taskcluster rather than TaskCluster.